### PR TITLE
Fixed various problems with article lists

### DIFF
--- a/src/components/ArticleList.astro
+++ b/src/components/ArticleList.astro
@@ -20,29 +20,31 @@ let list = posts.map((p) => ({
 {
 	list.map((article) => (
 		<article class="mt-10 md:flex md:items-center md:h-[263px]">
-			<OptimizedPicture
-				src={article.image}
-				class="object-cover w-full h-96 mb-4 md:min-w-[263px] md:max-w-[263px] md:h-full md:mb-0"
-				alt={article.title}
-			/>
+			<a href={`/posts/${article.slug}`} class="w-full h-[250px] mb-4 md:min-w-[263px] md:max-w-[263px] md:h-full md:mb-0">
+				<OptimizedPicture
+					src={article.image}
+					class="object-cover w-full h-full"
+					alt={article.title}
+				/>
+			</a>
 			<div class="md:ml-7">
 				<a href={`/posts/${article.slug}`}>
 					<h3 class="title-small hover:text-primary">{article.title}</h3>
 					<span class="text-overline-small">
 						{article.date.toLocaleDateString('el-gr')} •
-						{article.categories.map((c) => (
-							<a
-								href={'/categories/' + c.slug}
-								class="text-overline-small hover:text-primary"
-							>
-								{
-									c.name
-									.normalize('NFD')/*decompose accented characters into: character + diacritical mark*/
-									.replace(/[\u0300-\u036f]/g, "")/*remove diacritical marks from name*/
-								}
-							</a>
-						))}
 					</span>
+					{article.categories.map((c) => (
+						<a
+							href={'/categories/' + c.slug}
+							class="text-overline-small hover:text-primary mr-1"
+						>
+							{
+								c.name
+								.normalize('NFD')/*decompose accented characters into: character + diacritical mark*/
+								.replace(/[\u0300-\u036f]/g, "")/*remove diacritical marks from name*/
+							}
+						</a>
+					))}
 				</a>
 				<p class="text-body-small mt-4"> {article.shortText} </p>
 				<a

--- a/src/components/ArticleListPage.astro
+++ b/src/components/ArticleListPage.astro
@@ -4,7 +4,7 @@ import ArticleList from './ArticleList.astro';
 const { posts, title } = Astro.props;
 ---
 
-<div class="px-5 max-w-[750px] mx-auto mb-24">
+<div class="px-10 max-w-[750px] mx-auto mb-24">
 	<h1 class="title-large text-center mb-5 mt-20">
 		{title}
 	</h1>

--- a/src/components/HeroSection.astro
+++ b/src/components/HeroSection.astro
@@ -13,28 +13,23 @@ let post = posts[0];
 let post_categories = wordpress.getCategoriesFromPost(post);
 ---
 
-<article>
-	<a
-		href={`/posts/${post.slug}`}
-		class="flex flex-col md:flex-row md:items-center"
-	>
-		<!-- <img
-			src={post.featured_image}
-			alt=""
-			class="w-full max-h-[240px] md:max-h-[383px] object-cover md:max-w-[555px] md:flex-1"
-		/> -->
-		<OptimizedPicture
-			src={post.featured_image}
-			alt={parse(post.title).text}
-			class="w-full overflow-hidden max-h-[240px] md:max-h-[383px] object-cover md:max-w-[555px] md:flex-1"
-		/>
-		<div class="md:my-11 md:ml-11 md:flex-1">
+<article class="flex flex-col md:flex-row md:items-center">
+		<a
+			href={`/posts/${post.slug}`}
+			class="h-[240px] md:min-h-[383px] bg-black md:w-[50%] grow" 
+		>
+			<OptimizedPicture
+				src={post.featured_image}
+				alt={parse(post.title).text}
+				class="object-cover w-full h-full"
+			/>
+		</a>
+		<div class="md:w-[50%] grow md:p-11">
 			<p class="text-overline mt-6">
 				{
-					//todo: fix this so it has an <a> elem instead of span
 					post_categories.map((c) => (
-						<span 
-							href={'/categories/' + c.slug} 
+						<a
+							href={'/categories/' + c.slug}
 							class="hover:text-primary"
 						>
 							{
@@ -42,14 +37,14 @@ let post_categories = wordpress.getCategoriesFromPost(post);
 								.normalize('NFD')/*decompose accented characters into: character + diacritical mark*/
 								.replace(/[\u0300-\u036f]/g, "")/*remove diacritical marks from name*/
 							}
-						</span>
+						</a>
 					))
 				}
 			</p>
-			<h3 class="title-large my-4 hover:text-primary">{parse(post.title).text}</h3>
+			
+			<a href={`/posts/${post.slug}`}><h3 class="title-large my-4 hover:text-primary">{parse(post.title).text}</h3></a>
 			<p class="text-body">
 				{wordpress.getExcerptFromPost(post)}
 			</p>
 		</div>
-	</a>
 </article>

--- a/src/components/OptimizedPicture.astro
+++ b/src/components/OptimizedPicture.astro
@@ -42,6 +42,6 @@ if (src != null) {
 			/>
 		</div>
 	) : (
-		<div class:list={[cl,"bg-primary"]}/>
+		<div class:list={[cl,"bg-[rgba(217,217,217,1)]"]}/>
 	)
 }

--- a/src/components/PlainImagePost.astro
+++ b/src/components/PlainImagePost.astro
@@ -5,7 +5,7 @@ export interface Props {
 	title: string;
 	image: string;
 	href: string;
-	categories?: any[];
+	categories?: {name:string, slug:string}[];
 	class?: string;
 }
 

--- a/src/components/PlainImagePost.astro
+++ b/src/components/PlainImagePost.astro
@@ -5,7 +5,7 @@ export interface Props {
 	title: string;
 	image: string;
 	href: string;
-	categories?: string[];
+	categories?: any[];
 	class?: string;
 }
 
@@ -16,7 +16,7 @@ const { title, image, href, categories, class: cl } = Astro.props;
 	<a href={href}>
 		<OptimizedPicture
 			src={image}
-			class="object-cover w-full md:h-[186px] max-h-[247px] overflow-hidden"
+			class="object-cover w-full md:h-[186px] h-[250px] overflow-hidden"
 			alt={title}
 		/>
 		<h6 class="title-small mt-2 hover:text-primary">{title}</h6>
@@ -25,7 +25,7 @@ const { title, image, href, categories, class: cl } = Astro.props;
 			categories.map((c) => (
 				<a
 					href={'/categories/' + c.slug}
-					class="text-overline-small hover:text-primary"
+					class="text-overline-small hover:text-primary mr-1"
 				>
 					{
 						c.name

--- a/src/pages/posts/index.astro
+++ b/src/pages/posts/index.astro
@@ -23,22 +23,22 @@ postsByYear.sort((a, b) => b.year - a.year);
 ---
 
 <BasePage title="Όλα τα άρθρα" permalink="/posts">
-	<div class="px-5 max-w-[920px] mx-auto mb-24">
+	<div class="px-10 md:max-w-[1000px] mx-auto mb-24">
 		<h1 class="title-large text-center mb-14 mt-20">Όλα τα άρθρα</h1>
 		{
 			postsByYear.map((y) => (
 				<div class="md:flex">
-					<p class="title-small text-[#424242] md:mr-4 text-center mb-6 md:text-left">
+					<p class="title-small text-[#424242] md:mr-10 text-center mb-6">
 						{y.year}
 					</p>
-					<div class="md:flex flex-wrap justify-around">
+					<div class="md:flex flex-wrap grow justify-start gap-x-5">
 						{y.posts.map((p) => (
 							<PlainImagePost
 								title={p.title}
 								image={p.featured_image}
 								href={'/posts/' + p.slug}
 								categories={wordpress.getCategoriesFromPost(p)}
-								class="md:max-w-[263px] mb-14 overflow-hidden"
+								class="md:w-[calc((100%-2.5rem)/2)] lg:w-[calc((100%-2.5rem)/3)] mb-14"
 							/>
 						))}
 					</div>


### PR DESCRIPTION
### Various fixes for article lists
On `ArticleList` which is visible in category pages and homepage: Added small margin between category names (they was none before) , made the image link to the article when clicked.
On `HeroSection` I made the category links link to the category itself and not the article.
I made the placeholder image for articles that don't have a cover image a grey color instead of the main color we had before which I think distracted too much.
![Screenshot 2025-01-29 205733](https://github.com/user-attachments/assets/c21a0df6-225a-4a7b-897a-6c562069746d)

Fixed the _"All articles"_ page to look like the design. Now the articles are arranged in a responsive grid and all have the same size.
![Screenshot 2025-01-29 205407](https://github.com/user-attachments/assets/027ab279-41b5-421c-b856-b2ca3a69a4df)
