### PR TITLE
Change to Navbar scaling on mobile plus some small styling changes

### DIFF
--- a/src/components/ArticleList.astro
+++ b/src/components/ArticleList.astro
@@ -27,7 +27,7 @@ let list = posts.map((p) => ({
 					alt={article.title}
 				/>
 			</a>
-			<div class="md:ml-7">
+			<div class="mt-3 md:mt-0 md:ml-7">
 				<a href={`/posts/${article.slug}`}>
 					<h3 class="title-small hover:text-primary">{article.title}</h3>
 					<span class="text-overline-small">

--- a/src/components/ArticleListPage.astro
+++ b/src/components/ArticleListPage.astro
@@ -4,7 +4,7 @@ import ArticleList from './ArticleList.astro';
 const { posts, title } = Astro.props;
 ---
 
-<div class="px-10 max-w-[750px] mx-auto mb-24">
+<div class="px-5 max-w-[750px] mx-auto mb-24">
 	<h1 class="title-large text-center mb-5 mt-20">
 		{title}
 	</h1>

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -50,20 +50,20 @@ const items = [
 <nav
 	class="w-full mt-4 border-t-3 border-b-3 border-black text-center relative"
 >
-	<div class="inline-grid grid-flow-col auto-cols-fr mx-auto">
+	<div class="inline-grid grid-flow-col auto-cols-fr mx-auto w-full sm:w-auto overflow-y-hidden">
 	{
 		items.map((it) => {
 			return (it.href != null ? (
 				// Link
 				<div class="min-h-full hover:bg-black hover:text-white">
-					<a href={it.href} class="min-h-full w-full title-small px-5 md:px-10 py-2 text-center mx-auto inline-block focus-visible:bg-black focus-visible:text-white">
+					<a href={it.href} class="min-h-full w-full title-xsmall sm:title-small px-2 sm:px-5 md:px-10 py-2 text-center mx-auto inline-block focus-visible:bg-black focus-visible:text-white">
 						{it.text}
 					</a>
 				</div>
 			) : (
 				// Dropdown menu
 				<div class="dropdown hover:bg-black hover:text-white  [&.expand]:bg-black [&.expand]:text-white">
-					<button class="dropdown-btn min-h-full w-full title-small px-5 md:px-10 py-2 focus-visible:bg-black focus-visible:text-white">
+					<button class="dropdown-btn min-h-full w-full title-xsmall sm:title-small px-2 sm:px-5 md:px-10 py-2 focus-visible:bg-black focus-visible:text-white">
 						{it.text}
 					</button>
 

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -56,14 +56,14 @@ const items = [
 			return (it.href != null ? (
 				// Link
 				<div class="min-h-full hover:bg-black hover:text-white">
-					<a href={it.href} class="min-h-full w-full title-xsmall sm:title-small px-2 sm:px-5 md:px-10 py-2 text-center mx-auto inline-block focus-visible:bg-black focus-visible:text-white">
+					<a href={it.href} class="min-h-full w-full title-xsmall sm:title-small px-1 sm:px-5 md:px-10 py-2 text-center mx-auto inline-block focus-visible:bg-black focus-visible:text-white">
 						{it.text}
 					</a>
 				</div>
 			) : (
 				// Dropdown menu
 				<div class="dropdown hover:bg-black hover:text-white  [&.expand]:bg-black [&.expand]:text-white">
-					<button class="dropdown-btn min-h-full w-full title-xsmall sm:title-small px-2 sm:px-5 md:px-10 py-2 focus-visible:bg-black focus-visible:text-white">
+					<button class="dropdown-btn min-h-full w-full title-xsmall sm:title-small px-1 sm:px-5 md:px-10 py-2 focus-visible:bg-black focus-visible:text-white">
 						{it.text}
 					</button>
 
@@ -72,7 +72,7 @@ const items = [
 							<ul class="inline-block">
 								{it.subitems.map((i) => (
 									<a class="hover:underline mx-auto" href={i.href}>
-										<li class="py-3 title-small px-4">
+										<li class="py-3 title-xsmall sm:title-small px-4">
 											{i.text}
 										</li>
 									</a>

--- a/src/components/PlainImagePost.astro
+++ b/src/components/PlainImagePost.astro
@@ -19,7 +19,7 @@ const { title, image, href, categories, class: cl } = Astro.props;
 			class="object-cover w-full md:h-[186px] h-[250px] overflow-hidden"
 			alt={title}
 		/>
-		<h6 class="title-small mt-2 hover:text-primary">{title}</h6>
+		<h6 class="title-small mt-3 md:mt-2 hover:text-primary">{title}</h6>
 		{
 			categories &&
 			categories.map((c) => (

--- a/src/components/PlainImagePost.astro
+++ b/src/components/PlainImagePost.astro
@@ -20,7 +20,7 @@ const { title, image, href, categories, class: cl } = Astro.props;
 			alt={title}
 		/>
 	</a>
-	<a href={href}><h6 class="title-small mt-3 md:mt-2 hover:text-primaryy_bold">{title}</h6></a>
+	<a href={href}><h6 class="title-small mt-3 md:mt-2 hover:text-primary_bold">{title}</h6></a>
 	{
 		categories.map((c) => (
 			<a

--- a/src/pages/posts/index.astro
+++ b/src/pages/posts/index.astro
@@ -23,7 +23,7 @@ postsByYear.sort((a, b) => b.year - a.year);
 ---
 
 <BasePage title="Όλα τα άρθρα" permalink="/posts">
-	<div class="px-10 md:max-w-[1000px] mx-auto mb-24">
+	<div class="px-5 md:max-w-[1000px] mx-auto mb-24">
 		<h1 class="title-large text-center mb-14 mt-20">Όλα τα άρθρα</h1>
 		{
 			postsByYear.map((y) => (

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1,4 +1,5 @@
 /* text styles */
+@tailwind utilities;
 
 * {
 	font-family: Roboto, 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
@@ -16,49 +17,58 @@
 	letter-spacing: -0.02em;
 }
 
-.text-xxlarge {
-	font-family: Syne, 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-	font-weight: 500;
-	font-size: 56px;
-	line-height: 56px;
-	letter-spacing: -0.02em;
-}
+@layer utilities{
+	.text-xxlarge {
+		font-family: Syne, 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+		font-weight: 500;
+		font-size: 56px;
+		line-height: 56px;
+		letter-spacing: -0.02em;
+	}
 
-.title-xlarge {
-	font-family: Syne, 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-	font-weight: 400;
-	font-size: 32px;
-	line-height: 36px;
-	letter-spacing: -0.01em;
-}
+	.title-xlarge {
+		font-family: Syne, 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+		font-weight: 400;
+		font-size: 32px;
+		line-height: 36px;
+		letter-spacing: -0.01em;
+	}
 
-.title-large {
-	font-family: Syne, 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-	font-weight: 500;
-	font-size: 28px;
-	line-height: 32px;
-	letter-spacing: -0.02em;
-}
+	.title-large {
+		font-family: Syne, 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+		font-weight: 500;
+		font-size: 28px;
+		line-height: 32px;
+		letter-spacing: -0.02em;
+	}
 
-.title-medium {
-	font-family: Syne, 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-	font-weight: 500;
-	font-size: 24px;
-	line-height: 28px;
-}
+	.title-medium {
+		font-family: Syne, 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+		font-weight: 500;
+		font-size: 24px;
+		line-height: 28px;
+	}
 
-.title-medium-2 {
-	font-family: Syne, 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-	font-weight: 500;
-	font-size: 20px;
-	line-height: 24px;
-}
+	.title-medium-2 {
+		font-family: Syne, 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+		font-weight: 500;
+		font-size: 20px;
+		line-height: 24px;
+	}
 
-.title-small {
-	font-family: Syne, 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-	font-weight: 500;
-	font-size: 18px;
-	line-height: 24px;
+	.title-small {
+		font-family: Syne, 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+		font-weight: 500;
+		font-size: 18px;
+		line-height: 24px;
+	}
+
+	.title-xsmall {
+		font-family: Syne, 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+		font-weight: 500;
+		font-size: 16px;
+		line-height: 20px;
+	}
 }
 
 .text-body {


### PR DESCRIPTION
Fixed NavBar styling on mobile by making it's text and padding smaller. 
I added the `title-` CSS classes to the tailwind utility classes so they can be used in scaling. Might come handy in other use cases aswell.

Also fixed some small styling discrepancies.
