### PR TITLE
Support footnotes

### DIFF
--- a/src/components/BlogPost.astro
+++ b/src/components/BlogPost.astro
@@ -250,12 +250,12 @@ console.log(footnotes);
 	}
 
 	li:target {
-		animation: highlight 2s ease-out forwards;
+		animation: highlight 5s ease-out forwards;
 	}
 
 	@keyframes highlight {
 		0% {
-			background-color: #fff3cd;
+			background-color: #ffe17d;
 		}
 		100% {
 			background-color: transparent;
@@ -312,7 +312,13 @@ console.log(footnotes);
 											>
 												<Fragment
 													set:html={footnote.content}
-												/>
+												/>{' '}
+												<a
+													href={`#${footnote.id}-link`}
+													class="text-xs"
+												>
+													↩︎
+												</a>
 											</li>
 										))}
 									</ol>

--- a/src/components/BlogPost.astro
+++ b/src/components/BlogPost.astro
@@ -19,37 +19,49 @@ export interface Props {
 	featuredImage: string;
 	alt: string;
 	text: string;
-	tags: {ID:number , name:string , slug:string}[];
+	tags: { ID: number; name: string; slug: string }[];
 	id: number;
-	categories: {ID:number}[];
+	footnotes: { id: number; content: string }[];
+	categories: { ID: number }[];
 }
 
-const { title, author, tags, publishDate, featuredImage, alt, text, id , categories } = Astro.props;
+const {
+	title,
+	author,
+	tags,
+	publishDate,
+	featuredImage,
+	alt,
+	text,
+	id,
+	footnotes,
+	categories,
+} = Astro.props;
 
-const parsed_post = parse(text,{
+const parsed_post = parse(text, {
 	blockTextElements: {
-		script: false,		// keep text content when parsing
-		noscript: false,	// keep text content when parsing
-		style: false,		// keep text content when parsing
-		pre: false			// keep text content when parsing
- 	}
+		script: false, // keep text content when parsing
+		noscript: false, // keep text content when parsing
+		style: false, // keep text content when parsing
+		pre: false, // keep text content when parsing
+	},
 });
 
 function parseStyleAttribute(style_string) {
-    const parsed_styles = {};
-    style_string.split(';').forEach(rule => {
-        const [property, value] = rule.split(':');
-        if (property && value) {
-            parsed_styles[property] = value;
-        }
-    });
-    return parsed_styles;
+	const parsed_styles = {};
+	style_string.split(';').forEach((rule) => {
+		const [property, value] = rule.split(':');
+		if (property && value) {
+			parsed_styles[property] = value;
+		}
+	});
+	return parsed_styles;
 }
 
 function styleAttributeString(style_object) {
 	var style_string = '';
-	Object.entries(style_object).forEach(function([property, value]){
-		style_string+=`${property}:${value};`
+	Object.entries(style_object).forEach(function ([property, value]) {
+		style_string += `${property}:${value};`;
 	});
 	return style_string;
 }
@@ -61,74 +73,96 @@ function addIframeClasses(node) {
 
 // Get recommended posts
 // Gets 4 random posts that have common categories with the post
-let posts = await getCollection('posts',({ data }) => {
-	if(data.ID === id) return false; //Exclude self
+let posts = await getCollection('posts', ({ data }) => {
+	if (data.ID === id) return false; //Exclude self
 
 	//Check if candidate post has at least one common category or one common tag with post
 	const post_categories = wordpress.getCategoriesFromPost(data);
 	const post_tags = data.tags;
-	return ( categories.some(category => {
-		if(post_categories.some((post_category) => post_category.ID === category.ID)) return true;
-		return false;
-	}) 
-
-	||
-	 
-	Object.values(tags).some(tag=>{
-		if(Object.values(post_tags).some((post_tag) => post_tag.ID === tag.ID)) return true;
-		return false;
-	}));
+	return (
+		categories.some((category) => {
+			if (
+				post_categories.some(
+					(post_category) => post_category.ID === category.ID
+				)
+			)
+				return true;
+			return false;
+		}) ||
+		Object.values(tags).some((tag) => {
+			if (
+				Object.values(post_tags).some(
+					(post_tag) => post_tag.ID === tag.ID
+				)
+			)
+				return true;
+			return false;
+		})
+	);
 });
-posts = posts.map((p)=>{
+posts = posts.map((p) => {
 	return p.data;
 });
-let posts_number=posts.length; 
+let posts_number = posts.length;
 const recommended = [];
-for (let i = 0; i <= 3 && i+1<=posts_number; i++) {
+for (let i = 0; i <= 3 && i + 1 <= posts_number; i++) {
 	let index = Math.floor(Math.random() * posts.length);
 	recommended.push({
 		title: posts[index].title,
- 		id: posts[index].ID,
- 		slug: posts[index].slug,
- 		image: posts[index].featured_image,
+		id: posts[index].ID,
+		slug: posts[index].slug,
+		image: posts[index].featured_image,
 	});
 	posts.splice(index, 1);
 }
 // Pad recommendations with recent posts if there are less than 4
-if(recommended.length<4) {
-	let all_posts = await getCollection('posts',({ data }) => {
-		if(data.ID === id) return false; //Exclude self
+if (recommended.length < 4) {
+	let all_posts = await getCollection('posts', ({ data }) => {
+		if (data.ID === id) return false; //Exclude self
 		return true;
 	});
-	all_posts = all_posts.map((p)=>{
+	all_posts = all_posts.map((p) => {
 		return p.data;
 	});
 	const recent_posts = [];
 
-	for (let i = 0; i+1 <= all_posts.length && recent_posts.length < 15; i++) {
+	for (
+		let i = 0;
+		i + 1 <= all_posts.length && recent_posts.length < 15;
+		i++
+	) {
 		//Get 15 most recent posts
 		//Exclude similar posts from results
 		const post_categories = wordpress.getCategoriesFromPost(all_posts[i]);
 		const post_tags = all_posts[i].tags;
 
-		if(!(
-			categories.some(category => {
-				if(post_categories.some((post_category) => post_category.ID === category.ID)) return true;
-				return false;
-			}) 
-
-			||
-	 
-			Object.values(tags).some(tag=>{
-				if(Object.values(post_tags).some((post_tag) => post_tag.ID === tag.ID)) return true;
-				return false;
-			})
-		)){
+		if (
+			!(
+				categories.some((category) => {
+					if (
+						post_categories.some(
+							(post_category) => post_category.ID === category.ID
+						)
+					)
+						return true;
+					return false;
+				}) ||
+				Object.values(tags).some((tag) => {
+					if (
+						Object.values(post_tags).some(
+							(post_tag) => post_tag.ID === tag.ID
+						)
+					)
+						return true;
+					return false;
+				})
+			)
+		) {
 			recent_posts.push(all_posts[i]);
 		}
 	}
 
-	for (let i = recommended.length; i <= 3 && recent_posts.length>0; i++) {
+	for (let i = recommended.length; i <= 3 && recent_posts.length > 0; i++) {
 		let index = Math.floor(Math.random() * recent_posts.length);
 		recommended.push({
 			title: recent_posts[index].title,
@@ -143,46 +177,53 @@ if(recommended.length<4) {
 // Set first image in post as the hero image
 let first_image = parsed_post.querySelector('img');
 const heroImage = first_image ? first_image.getAttribute('data-orig-file') : '';
-if(first_image){
+if (first_image) {
 	first_image.remove();
 }
 // Add highlight color to links
 let links = parsed_post.getElementsByTagName('a');
-links.forEach(function(link_tag){
+links.forEach(function (link_tag) {
 	link_tag.classList.add('text-primary_bold');
 	link_tag.classList.add('font-normal');
-})
+});
 //Remove custom styling from text
-let styled_elements = parsed_post.querySelectorAll("[style]");
-styled_elements.forEach(function(element){
+let styled_elements = parsed_post.querySelectorAll('[style]');
+styled_elements.forEach(function (element) {
 	let styles = parseStyleAttribute(element.getAttribute('style'));
 	delete styles['font-family'];
 	delete styles['font-size'];
 	delete styles['color'];
 	delete styles['text-align'];
-	if(styles.length>0)
-		element.setAttribute('style',styleAttributeString(styles));
-	else
-		element.removeAttribute('style');
+	if (styles.length > 0)
+		element.setAttribute('style', styleAttributeString(styles));
+	else element.removeAttribute('style');
 });
 //Make iframes responsive and tweak styling
 let i_frames = parsed_post.getElementsByTagName('iframe');
-i_frames.forEach(function(i_frame){
+i_frames.forEach(function (i_frame) {
 	addIframeClasses(i_frame);
-})
+});
 // Change styling of paragraphs
 let paragraphs = parsed_post.getElementsByTagName('p');
-paragraphs.forEach(function(p){
+paragraphs.forEach(function (p) {
 	p.classList.add('my-4');
 	//Replace the &nbsp; character that is used on some paragraphs and breaks the formatting
 	p.innerHTML = p.innerHTML.replace(/\&nbsp;/g, '');
 });
 
+// Replace wp-block-footnotes with a placeholder so we can render custom footnotes in place
+let wp_footnotes = parsed_post.querySelector('ol.wp-block-footnotes');
+if (wp_footnotes) {
+	const parent = wp_footnotes.parentNode;
+	const placeholder = parse('<div data-footnotes-placeholder="true"></div>');
+	parent.exchangeChild(wp_footnotes, placeholder);
+}
+
 let processed_post = parsed_post.childNodes.map((v) => {
 	if (v == null) return;
 	if (v.nodeType !== 1) {
-        return v;
-    }
+		return v;
+	}
 
 	if (v.tagName != null) {
 		v.classList.add('mx-auto');
@@ -191,7 +232,7 @@ let processed_post = parsed_post.childNodes.map((v) => {
 
 	let images = v.querySelectorAll('img');
 	if (images.length > 0) {
-		images.forEach(function(image) {
+		images.forEach(function (image) {
 			image.classList.add('my-4');
 			image.classList.add('mx-auto');
 		});
@@ -199,11 +240,26 @@ let processed_post = parsed_post.childNodes.map((v) => {
 
 	return v;
 });
+
+console.log(footnotes);
 ---
 
 <style>
 	button.pressed {
 		background-color: #424242 !important;
+	}
+
+	li:target {
+		animation: highlight 2s ease-out forwards;
+	}
+
+	@keyframes highlight {
+		0% {
+			background-color: #fff3cd;
+		}
+		100% {
+			background-color: transparent;
+		}
 	}
 </style>
 
@@ -233,14 +289,38 @@ let processed_post = parsed_post.childNodes.map((v) => {
 									src={v.getAttribute('data-orig-file')}
 									alt={v.getAttribute('alt')}
 									title={v.getAttribute('data-image-title')}
-									caption={v.getAttribute('data-image-caption')}
+									caption={v.getAttribute(
+										'data-image-caption'
+									)}
 									height={v.getAttribute('height')}
 									class="my-4 md:max-w-xl md:mx-auto"
 								/>
 							);
 						}
 
-						return <Fragment set:html={v}/>;
+						if (
+							v.querySelector &&
+							v.querySelector('[data-footnotes-placeholder]')
+						) {
+							return footnotes && footnotes.length > 0 ? (
+								<section class="my-10 mx-auto md:max-w-[750px]">
+									<ol class="list-decimal list-inside">
+										{footnotes.map((footnote) => (
+											<li
+												id={footnote.id}
+												class="py-1 italic text-sm"
+											>
+												<Fragment
+													set:html={footnote.content}
+												/>
+											</li>
+										))}
+									</ol>
+								</section>
+							) : null;
+						}
+
+						return <Fragment set:html={v} />;
 					})
 				}
 			</main>
@@ -252,97 +332,112 @@ let processed_post = parsed_post.childNodes.map((v) => {
 				}
 			</p>
 			<!-- Share -->
-			<p class="md:max-w-[750px] mx-auto text-body mt-4" id="share_section">
+			<p
+				class="md:max-w-[750px] mx-auto text-body mt-4"
+				id="share_section"
+			>
 				<span class="mr-1" style="font-weight: 400">SHARE</span>
-				
-				<button class="hidden bg-primary rounded-md px-2 py-[1px] text-white" id="copy_link">
+
+				<button
+					class="hidden bg-primary rounded-md px-2 py-[1px] text-white"
+					id="copy_link"
+				>
 					<span id="button_text">Αντιγραφή συνδέσμου</span>
-					<span class="material-symbols-sharp text-[18px]/[24px] align-bottom">link</span>
+					<span
+						class="material-symbols-sharp text-[18px]/[24px] align-bottom"
+					>
+						link
+					</span>
 				</button>
 
-				<button class="hidden bg-primary rounded-md px-2 py-[1px] text-white" id="native_share">
+				<button
+					class="hidden bg-primary rounded-md px-2 py-[1px] text-white"
+					id="native_share"
+				>
 					<span>Κοινοποίηση</span>
-					<span class="material-symbols-sharp text-[18px]/[24px] align-bottom">share</span>
+					<span
+						class="material-symbols-sharp text-[18px]/[24px] align-bottom"
+					>
+						share
+					</span>
 				</button>
-				
 			</p>
 			<!-- Tags -->
-			{Object.keys(tags).length > 0 &&
-				<p class="md:max-w-[750px] mx-auto text-body mt-4">
-					<span class="mr-1" style="font-weight: 400">TAGS</span>
-					/ 
-					{
-						Object.values(tags).map((t) => (
+			{
+				Object.keys(tags).length > 0 && (
+					<p class="md:max-w-[750px] mx-auto text-body mt-4">
+						<span class="mr-1" style="font-weight: 400">
+							TAGS
+						</span>
+						/
+						{Object.values(tags).map((t) => (
 							<>
 								<a href={'/tags/' + t.slug}>{t.name}</a> /
 							</>
-						))
-					}
-				</p>
+						))}
+					</p>
+				)
 			}
 
 			<!-- Recommended posts -->
-			{recommended.length>0 &&
-				<div class="md:max-w-[1200px] mx-auto mt-20">
-					<h5 class="mb-10 title-medium md:text-center">
-						Διαβάστε ακόμα
-					</h5>
-					<div class="flex justify-center gap-x-5 gap-y-5 flex-wrap">
-						{
-							recommended &&
-							recommended.map((r) => {
-								return (
-									<PlainImagePost
-										title={parse(r.title).text}
-										image={r.image}
-										href={'/posts/' + r.slug}
-										class="md:w-[calc((100%-3.75rem)/4)] sm:w-[calc((100%-1.25rem)/2)] w-full"
-									/>
-								);
-							})
-						}
+			{
+				recommended.length > 0 && (
+					<div class="md:max-w-[1200px] mx-auto mt-20">
+						<h5 class="mb-10 title-medium md:text-center">
+							Διαβάστε ακόμα
+						</h5>
+						<div class="flex justify-center gap-x-5 gap-y-5 flex-wrap">
+							{recommended &&
+								recommended.map((r) => {
+									return (
+										<PlainImagePost
+											title={parse(r.title).text}
+											image={r.image}
+											href={'/posts/' + r.slug}
+											class="md:w-[calc((100%-3.75rem)/4)] sm:w-[calc((100%-1.25rem)/2)] w-full"
+										/>
+									);
+								})}
+						</div>
 					</div>
-				</div>
+				)
 			}
 		</div>
 	</article>
 </div>
 
-
-<script define:vars={{title}}>
+<script define:vars={{ title }}>
 	const copyLinkButton = document.querySelector('#copy_link');
 	const copyLinktext = copyLinkButton.querySelector('#button_text');
 	const nativeShareButton = document.querySelector('#native_share');
 	const shareSection = document.querySelector('#share_section');
 
 	const shareData = {
-		title: 'Μπομπίνα | ' + title ,
-		text: 'Μπομπίνα | ' + title ,
-		url: window.location.href //TODO : maybe implement some kind of shortened url for easier sharing
-	}
+		title: 'Μπομπίνα | ' + title,
+		text: 'Μπομπίνα | ' + title,
+		url: window.location.href, //TODO : maybe implement some kind of shortened url for easier sharing
+	};
 
 	// Check if browser supports native sharing functionality
 	if (navigator.canShare && navigator.canShare(shareData)) {
 		nativeShareButton.addEventListener('click', async () => {
 			try {
-    			await navigator.share(shareData);
- 			} catch (error) {
-    			console.log(error);
- 			}
+				await navigator.share(shareData);
+			} catch (error) {
+				console.log(error);
+			}
 		});
 		nativeShareButton.classList.remove('hidden');
-	}
-	else if(navigator.clipboard){
+	} else if (navigator.clipboard) {
 		copyLinkButton.addEventListener('click', () => {
 			navigator.clipboard.writeText(shareData.url).then(() => {
-				copyLinktext.innerText = "Αντιγράφηκε!"
+				copyLinktext.innerText = 'Αντιγράφηκε!';
 				copyLinkButton.classList.add('pressed');
-			})
+			});
 		});
 
 		copyLinkButton.classList.remove('hidden');
-	}
-	else{
+	} else {
 		shareSection.remove();
 	}
 </script>

--- a/src/components/MainGrid.astro
+++ b/src/components/MainGrid.astro
@@ -20,13 +20,13 @@ const { class: cl } = Astro.props;
 					Βιογραφίες
 				</GridItem>
 				<GridItem 
-					class='flex grow w-[50%]' img="assets/category_imgs/categories_director_positions.jpg" href="/categories/θέσεις-σκηνοθετών"
+					class='flex grow w-[50%]' img="assets/category_imgs/categories_director_positions.jpg" href="/categories/αφιερώματα"
 					img_style="filter:brightness(70%) contrast(230%);"
 					overlay_color="rgba(197, 138, 138, 0.54)"
 					overlay_filter="brightness(65%) contrast(160%) saturate(190%)"
 					overlay_opacity="0.5";
 				>
-					Θέσεις σκηνοθετών
+					Aφιερώματα
 				</GridItem>
 			</div>
 			<div class='flex gap-x-5 grow h-[calc(50%-10px)]'>

--- a/src/layouts/BasePage.astro
+++ b/src/layouts/BasePage.astro
@@ -16,7 +16,7 @@ export interface Props {
 const { title, description, permalink, heroImage } = Astro.props;
 ---
 
-<html lang="el">
+<html lang="el" style="scroll-behavior: smooth">
 	<head>
 		<BaseHead {title} {description} {permalink} {heroImage} />
 	</head>

--- a/src/pages/posts/[post].astro
+++ b/src/pages/posts/[post].astro
@@ -36,6 +36,7 @@ const content = {
 	id: post.ID,
 	slug: post.slug,
 	tags: post.tags,
+	footnotes: post.footnotes,
 	categories: wordpress.getCategoriesFromPost(post),
 };
 ---
@@ -55,6 +56,7 @@ const content = {
 		alt={content.alt}
 		text={content.text}
 		id={content.id}
+		footnotes={content.footnotes}
 		categories={content.categories}
 	/>
 </BasePage>

--- a/src/wordpress/index.js
+++ b/src/wordpress/index.js
@@ -2,40 +2,139 @@ import { parse } from 'node-html-parser';
 import axios from 'axios';
 
 const siteUrl =
-	'https://public-api.wordpress.com/rest/v1.1/sites/mpompina.wordpress.com';
+	'https://public-api.wordpress.com/wp/v2/sites/mpompina.wordpress.com';
 
 const DEFAULT_CATEGORY = 48775454; //this is the ID of the "default" category on wordpress
 const NO_CATEGORY = 1; //this is the ID of the "uncategorized" category on wordpress
 
 /**
+ * Resolves a category slug to its ID via the API.
+ * @param {String} slug
+ * @returns {Number|null}
+ */
+async function getCategoryIdBySlug(slug) {
+	let resp = await axios({
+		url: siteUrl + '/categories',
+		method: 'GET',
+		params: { slug },
+	});
+	if (resp.data.length > 0) return resp.data[0].id;
+	return null;
+}
+
+/**
+ * Resolves a tag slug to its ID via the API.
+ * @param {String} slug
+ * @returns {Number|null}
+ */
+async function getTagIdBySlug(slug) {
+	let resp = await axios({
+		url: siteUrl + '/tags',
+		method: 'GET',
+		params: { slug },
+	});
+	if (resp.data.length > 0) return resp.data[0].id;
+	return null;
+}
+
+/**
+ * Normalizes a v2 post object (fetched with _embed) to match the v1.1 shape
+ * used throughout the codebase.
+ * @param {Object} post raw v2 post object
+ * @returns {Object} normalized post
+ */
+function normalizePost(post) {
+	// Build categories object keyed by name (v1.1 shape)
+	const categories = {};
+	const embeddedTerms = post._embedded?.['wp:term'] || [];
+	const embeddedCategories = embeddedTerms[0] || [];
+	const embeddedTags = embeddedTerms[1] || [];
+
+	for (const cat of embeddedCategories) {
+		categories[cat.name] = { ID: cat.id, name: cat.name, slug: cat.slug };
+	}
+
+	// Build tags object keyed by name (v1.1 shape)
+	const tags = {};
+	for (const tag of embeddedTags) {
+		tags[tag.name] = { ID: tag.id, name: tag.name, slug: tag.slug };
+	}
+
+	// Resolve featured image URL from embedded media
+	const featuredMedia = post._embedded?.['wp:featuredmedia'] || [];
+	const featured_image =
+		featuredMedia.length > 0 ? featuredMedia[0].source_url || '' : '';
+
+	return {
+		ID: post.id,
+		title: post.title?.rendered || '',
+		slug: post.slug,
+		date: post.date,
+		content: post.content?.rendered || '',
+		excerpt: post.excerpt?.rendered || '',
+		featured_image,
+		featured_media: post.featured_media,
+		URL: post.link,
+		categories,
+		tags,
+		sticky: post.sticky,
+		// Keep the raw _embedded for any advanced use
+		_embedded: post._embedded,
+	};
+}
+
+/**
  * Returns an array of posts from the API
  * @param {Number} [max] the maximum number of posts to return
- * @param {String} [page_handle] used for pagination, the URL of the previous page //TODO: verfy that
- * @param {String} [category] the string of the category of the posts to filter by
- * @param {String} [tag] the string of the tag of the posts to filter by
+ * @param {Number|String} [page] page number for pagination (pass next_page from meta)
+ * @param {String} [category] the slug of the category to filter by
+ * @param {String} [tag] the slug of the tag to filter by
  * @param {Number} [offset] offset for first post to be retrieved
- * @returns {Object} {data: Object[], resp: Object} data is an array of posts, resp is the response object for whatever purposes
+ * @returns {Object} {data: {posts, found, meta}, resp} maintains v1.1 shape for callers
  */
 async function getPosts(
 	max = 20,
-	page_handle = '',
+	page = '',
 	category = '',
 	tag = '',
 	offset = 0
 ) {
+	const params = {
+		per_page: max,
+		page: page || 1,
+		offset,
+		_embed: true,
+	};
+
+	if (category) {
+		const catId = await getCategoryIdBySlug(category);
+		if (catId) params.categories = catId;
+	}
+
+	if (tag) {
+		const tagId = await getTagIdBySlug(tag);
+		if (tagId) params.tags = tagId;
+	}
+
 	let resp = await axios({
 		url: siteUrl + '/posts',
 		method: 'GET',
-		params: {
-			number: max,
-			page_handle: page_handle,
-			category,
-			tag,
-			offset,
-		},
+		params,
 	});
 
-	let data = resp.data;
+	const totalPosts = parseInt(resp.headers['x-wp-total'] || '0', 10);
+	const totalPages = parseInt(resp.headers['x-wp-totalpages'] || '0', 10);
+	const currentPage = params.page;
+
+	const posts = resp.data.map(normalizePost);
+
+	const data = {
+		posts,
+		found: totalPosts,
+		meta: {
+			next_page: currentPage < totalPages ? currentPage + 1 : '',
+		},
+	};
 
 	return { data, resp };
 }
@@ -43,21 +142,34 @@ async function getPosts(
 /**
  * Returns an array of posts from the API that have the sticky flag set
  * @param {Number} [max] the maximum number of posts to return
- * @param {String} page_handle used for pagination, the URL of the previous page //TODO: verfy that
- * @returns {Object} {data: Object[], resp: Object} data is an array of posts, resp is the response object for whatever purposes}
+ * @param {Number|String} [page] page number for pagination
+ * @returns {Object} {data: {posts, found, meta}, resp} maintains v1.1 shape for callers
  */
-async function getStickyPosts(max = 20, page_handle = '') {
+async function getStickyPosts(max = 20, page = '') {
 	let resp = await axios({
 		url: siteUrl + '/posts',
 		method: 'GET',
 		params: {
-			number: max,
-			page_handle: page_handle,
-			sticky: 'require',
+			per_page: max,
+			page: page || 1,
+			sticky: true,
+			_embed: true,
 		},
 	});
 
-	let data = resp.data;
+	const totalPosts = parseInt(resp.headers['x-wp-total'] || '0', 10);
+	const totalPages = parseInt(resp.headers['x-wp-totalpages'] || '0', 10);
+	const currentPage = page || 1;
+
+	const posts = resp.data.map(normalizePost);
+
+	const data = {
+		posts,
+		found: totalPosts,
+		meta: {
+			next_page: currentPage < totalPages ? currentPage + 1 : '',
+		},
+	};
 
 	return { data, resp };
 }
@@ -65,34 +177,63 @@ async function getStickyPosts(max = 20, page_handle = '') {
 /**
  * Returns the post with the given ID
  * @param {Number} id the ID of the post to get
- * @returns {Object} {data: Object, resp: Object} data is the post, resp is the response object for whatever purposes
+ * @returns {Object} {data: Object, resp: Object} data is the normalized post
  */
 async function getPost(id) {
-	let resp = await axios(siteUrl + `/posts/${id}`);
+	let resp = await axios({
+		url: siteUrl + `/posts/${id}`,
+		method: 'GET',
+		params: { _embed: true },
+	});
 
-	let data = resp.data;
+	let data = normalizePost(resp.data);
 
 	return { data, resp };
 }
 
 /**
  * Get an array with the wordpress categories
- * @returns
+ * @returns {Object} {data: Object[], resp: Object}
  */
 async function getCategories() {
-	let resp = await axios(siteUrl + '/categories');
-	let { categories: data } = resp.data;
+	let resp = await axios({
+		url: siteUrl + '/categories',
+		method: 'GET',
+		params: { per_page: 100 },
+	});
+
+	// Normalize to v1.1 shape (ID, name, slug fields)
+	let data = resp.data.map((cat) => ({
+		ID: cat.id,
+		name: cat.name,
+		slug: cat.slug,
+		description: cat.description,
+		parent: cat.parent,
+		post_count: cat.count,
+	}));
 
 	return { data, resp };
 }
 
 /**
  * Get an array with the wordpress tags
- * @returns
+ * @returns {Object} {data: Object[], resp: Object}
  */
 async function getTags() {
-	let resp = await axios(siteUrl + '/tags');
-	let { tags: data } = resp.data;
+	let resp = await axios({
+		url: siteUrl + '/tags',
+		method: 'GET',
+		params: { per_page: 100 },
+	});
+
+	// Normalize to v1.1 shape (ID, name, slug fields)
+	let data = resp.data.map((tag) => ({
+		ID: tag.id,
+		name: tag.name,
+		slug: tag.slug,
+		description: tag.description,
+		post_count: tag.count,
+	}));
 
 	return { data, resp };
 }
@@ -154,18 +295,14 @@ function getExcerptFromPost(post, max_chars) {
 }
 
 /**
- * Gets a preview image from the post incase there is no featured image
+ * Gets a preview image from the post. Uses the featured_image field
+ * which is resolved from _embedded media in normalizePost.
  * @param {Object} post
  * @returns {string} string with the url of the image
  */
 function getFeaturedImage(post) {
 	if (post.featured_image) {
 		return post.featured_image;
-	} else if (
-		post.attachment_count > 0 &&
-		Object.values(post.attachments)[0].mime_type.startsWith('image/')
-	) {
-		return Object.values(post.attachments)[0].URL;
 	}
 	return '';
 }

--- a/src/wordpress/index.js
+++ b/src/wordpress/index.js
@@ -60,6 +60,11 @@ function normalizePost(post) {
 		tags[tag.name] = { ID: tag.id, name: tag.name, slug: tag.slug };
 	}
 
+	let footnotes = [];
+	try {
+		footnotes = JSON.parse(post.meta.footnotes);
+	} catch (error) {}
+
 	// Resolve featured image URL from embedded media
 	const featuredMedia = post._embedded?.['wp:featuredmedia'] || [];
 	const featured_image =
@@ -78,6 +83,7 @@ function normalizePost(post) {
 		categories,
 		tags,
 		sticky: post.sticky,
+		footnotes,
 		// Keep the raw _embedded for any advanced use
 		_embedded: post._embedded,
 	};


### PR DESCRIPTION
Change to wordpress rest api v2 but with a compatibility wrapper.
Detect WP footnotes and Inject custom footnotes element.

Fixes #62 and maybe #50


Article for testing is [here](https://mpompina.kinimatografiko.gr/posts/%CF%84%CE%BF-7%CE%BF-giff-%CE%BC%CE%B5%CF%83%CE%B1-%CE%B1%CF%80%CE%BF-%CF%84%CE%B1-%CE%BC%CE%B1%CF%84%CE%B9%CE%B1-%CF%84%CE%B7%CF%82-%CE%BC%CF%80%CE%BF%CE%BC%CF%80%CE%B9%CE%BD%CE%B1%CF%82/)

Please note that I have manually entered HTML footnotes (adding the class `__custom_temp_footnotes`) in the article body temporarily so it work in the current site. 